### PR TITLE
Embed multiple images in the preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Twitter Link Expander — Telegram Bot
+
 ![banner-2](https://user-images.githubusercontent.com/6843656/182035588-e6ab4eda-6361-44b6-9b8c-ff660f18eabf.png)
 
-Some Twitter links stopped expanding inside Telegram which made it extremely annoying when you wanted to send some banger tweet to your homies in the group chat. This bot replies with an alternative [vxtwitter.com](https://vxtwitter.com) URL which has a working embed and even includes inline video.
-
+Some Twitter links stopped expanding inside Telegram which made it extremely annoying when you wanted to send some banger tweet to your homies in the group chat. This bot replies with an alternative [vxtwitter.com](https://vxtwitter.com) URL which has a working embed for multiple photos and even includes inline video.
 
 > **Note**
 >
-> There is no message logging or personal tracking — your chats stay private. 
+> There is no message logging or personal tracking — your chats stay private.
 >
 > The exact source code that’s published on GitHub is automatically [deployed to Railway](https://railway.app?referralCode=dev) and logs will never include any user/chat/personal info or content. You can audit the code to see for yourself.
 
 ## Demo
+
 https://user-images.githubusercontent.com/6843656/182036672-5b566200-cba4-462d-ba5c-4c043e032b06.mp4
 
-
-
 ## How to use this bot?
+
 1. Find it on Telegram as `@TwitterLinkExpanderBot` or click here: https://t.me/twitterlinkexpanderbot
 2. Add it to your group chat.
 3. Send a message that includes a tweet URL.
@@ -24,12 +24,13 @@ https://user-images.githubusercontent.com/6843656/182036672-5b566200-cba4-462d-b
 <img width="253" alt="image" src="https://user-images.githubusercontent.com/6843656/181651653-a6421462-2321-4344-8605-f5f32edc5047.png">
 
 ## Do you read all messages inside the chat?
+
 🙅‍♂️ **No, I will never do that.** 🙅‍♂️
 
-While it is technically possible through the Bot API, I simply do not have the time or desire to snoop on your shit. The only thing I keep track of is counting anonymous events when a "Yes" or "No" button is clicked to see if people are finding this bot helpful. 
+While it is technically possible through the Bot API, I simply do not have the time or desire to snoop on your shit. The only thing I keep track of is counting anonymous events when a "Yes" or "No" button is clicked to see if people are finding this bot helpful.
 
 <img width="593" alt="image" src="https://user-images.githubusercontent.com/6843656/182036390-25cbf7c9-1583-4038-a67f-081f6c190101.png">
 
-
 # Thanks
+
 Huge thank you to [@dylanpdx](https://github.com/dylanpdx) for creating [BetterTwitFix](https://github.com/dylanpdx/BetterTwitFix) / [vxtwitter.com](https://vxtwitter.com), which makes this bot possible.

--- a/tweet-parser.js
+++ b/tweet-parser.js
@@ -1,0 +1,23 @@
+import fetch from "node-fetch";
+
+export const fetchTweet = async (url) => {
+  const tweetId = url.split("/").pop().split("?")[0];
+
+  try {
+    const response = await fetch(`https://api.twitter.com/1.1/statuses/show.json?id=${tweetId}&tweet_mode=extended`, {
+      headers: {
+        Authorization: `Bearer ${process.env.TWITTER_TOKEN}`,
+      },
+    });
+    const data = await response.json();
+    const hasImages = data.extended_entities && data.extended_entities.media.length > 1;
+
+    if (hasImages) {
+      fetch(`https://qckm.io?m=twitter.link.multipleImages&v=1&k=${process.env.QUICKMETRICS_TOKEN}`);
+    }
+
+    return hasImages;
+  } catch (error) {
+    console.error(url, error);
+  }
+};


### PR DESCRIPTION
Fixes #1 

# Tweet
https://twitter.com/artbyeleven/status/1563611472428924928

# Changes
- Bot will now fetch metadata about the tweet from Twitter's API and check if it contains multiple images.
- If multiple images are detected, the link will be replaced with `c.vxtwitter.com` to combine them into a single image for the preview.

| Before | After |
| ------ | ----- |
| ![PixelSnap 2022-10-21 at 4 02 30 AM@2x](https://user-images.githubusercontent.com/6843656/197093744-d66208a2-d948-471d-b561-fc23c36c0e2d.png) | ![PixelSnap 2022-10-21 at 4 03 17 AM@2x](https://user-images.githubusercontent.com/6843656/197093874-68b70e44-e0ef-43ce-9e3f-e54021196d8b.png) |
