### PR TITLE
Let author of original message delete expanded link

### DIFF
--- a/callbacks/destruct-expanded-link.ts
+++ b/callbacks/destruct-expanded-link.ts
@@ -1,0 +1,39 @@
+import { Context } from "grammy";
+import { deleteMessage } from "../actions/delete-message";
+import { trackEvent } from "../helpers/analytics";
+
+/**
+ * Handle responses to expanded link’s "❌ Delete" button
+ * @param ctx Telegram context
+ */
+export async function handleExpandedLinkDestruction(ctx: Context) {
+  const answer = ctx.update?.callback_query;
+  const chatId = answer?.message?.chat.id;
+  const messageId = answer?.message?.message_id;
+  const data = answer?.data;
+
+  // Discard malformed messages
+  if (!answer || !chatId || !messageId || !data) return;
+
+  if (data.includes("destruct:")) {
+    const destructData = data.split(":");
+    const originalAuthorId = Number(destructData[1]);
+    const expansionType = destructData[2];
+    const answerGiverId = answer?.from?.id;
+
+    if (answerGiverId !== originalAuthorId) {
+      await ctx.answerCallbackQuery({
+        text: "This message can only be deleted by its original author.",
+        show_alert: true,
+      });
+
+      trackEvent(`destruct.${expansionType}.not-author-alert`);
+      return;
+    }
+
+    deleteMessage(chatId, messageId);
+    await ctx.answerCallbackQuery();
+    trackEvent(`destruct.${expansionType}.author`);
+    return;
+  }
+}

--- a/callbacks/index.ts
+++ b/callbacks/index.ts
@@ -5,6 +5,7 @@ import { handleManualExpand } from "./manual-expand";
 import { handleAutoexpandSettings } from "./settings-autoexpand";
 import { handleChangelogSettings } from "./settings-changelog";
 import { handlePermissionsSettings } from "./settings-permissions";
+import { handleExpandedLinkDestruction } from "./destruct-expanded-link";
 
 // Multiple bot.on("callback_query") functions cannot run in parallel.
 // The bot will only register the first one and ignore the rest.
@@ -18,6 +19,7 @@ bot.on("callback_query", async (ctx: Context) => {
   // Handle specific callbacks / button presses
   handleManualExpand(ctx);
   handleAutoexpandSettings(ctx);
+  handleExpandedLinkDestruction(ctx);
   handleChangelogSettings(ctx);
   handlePermissionsSettings(ctx);
 

--- a/callbacks/manual-expand.ts
+++ b/callbacks/manual-expand.ts
@@ -75,7 +75,7 @@ export async function handleManualExpand(ctx: Context) {
         };
 
         showBotActivity(chatId);
-        await expandLink(ctx, url, messageWithNoLinks, userInfo);
+        await expandLink(ctx, url, messageWithNoLinks, userInfo, "manual");
         deleteMessage(chatId, messageId); // bot’s [yes][no] message
         deleteFromCache(identifier);
 

--- a/link-listener.ts
+++ b/link-listener.ts
@@ -49,7 +49,7 @@ bot.on("message::url", async (ctx: Context) => {
 
     if (autoexpand) {
       // Expand link automatically with provided context
-      await expandLink(ctx, url, messageWithNoLinks, userInfo);
+      await expandLink(ctx, url, messageWithNoLinks, userInfo, "auto");
       // Delete message if it’s not a caption
       if (isDeletable) deleteMessage(chatId, msgId, ctx);
 


### PR DESCRIPTION
Fixes #32

- You send a link to expand.
- Bot automatically expands it and deletes your original message.
- For the next 15 seconds there is a button that allows the author of the original message to delete the bot’s message. It will show up for everyone but only the author is able to trigger the event that will delete the message.
- This button will also work in chats where the author is not an admin.
- After 15 seconds the bot edits that expanded message and removes the button.


![PixelSnap 2023-03-15 at 3 01 25 AM@2x](https://user-images.githubusercontent.com/6843656/225185436-5f2cd6dd-6a22-4ae6-ba42-97a470dd1b24.png)

![PixelSnap 2023-03-15 at 3 01 59 AM@2x](https://user-images.githubusercontent.com/6843656/225185481-c4db1957-9817-4d8f-921f-50c1179b9d50.png)
