### PR TITLE
Correctly handle forwarded messages

### DIFF
--- a/actions/expand-link.ts
+++ b/actions/expand-link.ts
@@ -67,6 +67,7 @@ export async function expandLink(
     const botReply = await ctx.api.sendMessage(
       chatId,
       expandedMessageTemplate(
+        ctx,
         userInfo.username,
         userInfo.userId,
         userInfo.firstName,
@@ -78,7 +79,7 @@ export async function expandLink(
         ...replyOptions,
         // Use HTML parse mode if the user does not have a username,
         // otherwise the bot will not be able to mention the user.
-        parse_mode: userInfo.username ? undefined : "HTML",
+        parse_mode: "HTML",
         reply_markup: {
           inline_keyboard: [
             [


### PR DESCRIPTION
Previously the bot would treat forwarded messages as a message coming from the person that did the forwarding. Now it will show a message when a message has been forwarded from another user or a channel.