### PR TITLE
fix @grammyjs/types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "isomorphic-unfetch": "^4.0.2",
     "node-cache": "^5.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "@grammyjs/types": "^2.12.1"
   },
   "scripts": {
     "start": "ts-node index.ts",
@@ -21,7 +22,6 @@
     "dev:debug": "DEV=true DEBUG=\"grammy*\" yarn dev"
   },
   "devDependencies": {
-    "@grammyjs/types": "^2.12.1",
     "@types/node": "^18.13.0",
     "ts-node-dev": "^2.0.0"
   }


### PR DESCRIPTION
It's being used by production code, so when the app is run without debug mode I was getting the following error:

> Cannot find module '@grammyjs/types' or its corresponding type declarations