### PR TITLE
improve resolveInstagramShare resolving the same url

### DIFF
--- a/helpers/instagram-share.ts
+++ b/helpers/instagram-share.ts
@@ -14,8 +14,12 @@ interface MetadataResponse {
  */
 export async function resolveInstagramShare(shareUrl: string): Promise<string | null> {
   try {
+    // Ensure the URL ends with a trailing slash to avoid unnecessary redirects
+    // (e.g., "https://www.instagram.com/share/xxx" might redirect to "https://www.instagram.com/share/xxx/").
+    const normalizedShareUrl = shareUrl.replace(/\/?$/, '/');
+
     const response = await axios.get<MetadataResponse>(
-      `https://og.metadata.vision/${encodeURIComponent(shareUrl)}`
+      `https://og.metadata.vision/${encodeURIComponent(normalizedShareUrl)}`
     );
 
     if (response.data?.data?.url) {


### PR DESCRIPTION
I have faced a case where `https://www.instagram.com/share/_z8cu4wLR` has been resolved to itself, somehow adding `/` solves the issue, but maybe you know a better solution, I haven't found any documentation for https://og.metadata.vision/