### PR TITLE
Hn parse fixes

### DIFF
--- a/actions/expand-link.ts
+++ b/actions/expand-link.ts
@@ -25,6 +25,7 @@ import { saveToCache, deleteFromCache } from "../helpers/cache";
 import { getButtonState } from "../helpers/button-states";
 import { resolveInstagramShare } from "../helpers/instagram-share";
 import { logger } from "../helpers/logger";
+import { escapeHtml } from "../helpers/sanitize-html";
 
 type UserInfoType = {
   username: string | undefined;
@@ -176,7 +177,7 @@ export async function expandLink(
 
         botReply = await ctx.api.sendPhoto(chatId, new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=600`)), {
           ...replyOptions,
-          caption: template + `\n\n<b>${truncatedTitle}</b>\n${truncatedDesc}`,
+          caption: template + `\n\n<b>${escapeHtml(truncatedTitle)}</b>\n${escapeHtml(truncatedDesc)}`,
           parse_mode: "HTML",
         });
 
@@ -186,7 +187,7 @@ export async function expandLink(
           await ctx.api.sendAudio(chatId, new InputFile(new URL(audio)), {
             ...replyOptions,
             title: truncatedTitle,
-            caption: audioDesc,
+            caption: escapeHtml(audioDesc),
             thumbnail: new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=200&h=200`)),
             parse_mode: "HTML",
             reply_markup: {
@@ -285,7 +286,7 @@ export async function expandLink(
 
           botReply = await ctx.api.sendPhoto(chatId, new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=600`)), {
             ...replyOptions,
-            caption: template + `\n\n<b>${truncatedTitle}</b>\n${truncatedDesc}`,
+            caption: template + `\n\n<b>${escapeHtml(truncatedTitle)}</b>\n${escapeHtml(truncatedDesc)}`,
             parse_mode: "HTML",
           });
 
@@ -295,7 +296,7 @@ export async function expandLink(
             await ctx.api.sendAudio(chatId, new InputFile(new URL(audio)), {
               ...replyOptions,
               title: truncatedTitle,
-              caption: audioDesc,
+              caption: escapeHtml(audioDesc),
               thumbnail: new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=200&h=200`)),
               parse_mode: "HTML",
               reply_markup: {

--- a/actions/expand-link.ts
+++ b/actions/expand-link.ts
@@ -183,7 +183,7 @@ export async function expandLink(
 
         if (audio) {
           // Also limit the audio caption
-          const audioDesc = description.length > 250 ? description.slice(0, 250) + "..." : description;
+          const audioDesc = description && description.length > 250 ? description.slice(0, 250) + "..." : (description || "");
           await ctx.api.sendAudio(chatId, new InputFile(new URL(audio)), {
             ...replyOptions,
             title: truncatedTitle,

--- a/actions/expand-link.ts
+++ b/actions/expand-link.ts
@@ -171,9 +171,9 @@ export async function expandLink(
         const titleMaxLength = Math.min(50, Math.floor(remainingSpace * 0.3));
         const descMaxLength = Math.floor(remainingSpace * 0.7);
 
-        const truncatedTitle = title.length > titleMaxLength ? title.slice(0, titleMaxLength) + "..." : title;
+        const truncatedTitle = title && title.length > titleMaxLength ? title.slice(0, titleMaxLength) + "..." : (title || "");
         const truncatedDesc =
-          description.length > descMaxLength ? description.slice(0, descMaxLength) + "..." : description;
+          description && description.length > descMaxLength ? description.slice(0, descMaxLength) + "..." : (description || "");
 
         botReply = await ctx.api.sendPhoto(chatId, new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=600`)), {
           ...replyOptions,
@@ -280,9 +280,9 @@ export async function expandLink(
           const titleMaxLength = Math.min(50, Math.floor(remainingSpace * 0.3)); // Max 50 chars for title
           const descMaxLength = Math.floor(remainingSpace * 0.7); // Rest for description
 
-          const truncatedTitle = title.length > titleMaxLength ? title.slice(0, titleMaxLength) + "..." : title;
+          const truncatedTitle = title && title.length > titleMaxLength ? title.slice(0, titleMaxLength) + "..." : (title || "");
           const truncatedDesc =
-            description.length > descMaxLength ? description.slice(0, descMaxLength) + "..." : description;
+            description && description.length > descMaxLength ? description.slice(0, descMaxLength) + "..." : (description || "");
 
           botReply = await ctx.api.sendPhoto(chatId, new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=600`)), {
             ...replyOptions,
@@ -292,7 +292,7 @@ export async function expandLink(
 
           if (audio) {
             // Also limit the audio caption
-            const audioDesc = description.length > 250 ? description.slice(0, 250) + "..." : description;
+            const audioDesc = description && description.length > 250 ? description.slice(0, 250) + "..." : (description || "");
             await ctx.api.sendAudio(chatId, new InputFile(new URL(audio)), {
               ...replyOptions,
               title: truncatedTitle,

--- a/actions/expand-link.ts
+++ b/actions/expand-link.ts
@@ -25,7 +25,7 @@ import { saveToCache, deleteFromCache } from "../helpers/cache";
 import { getButtonState } from "../helpers/button-states";
 import { resolveInstagramShare } from "../helpers/instagram-share";
 import { logger } from "../helpers/logger";
-import { escapeHtml } from "../helpers/sanitize-html";
+import { escapeHtmlSafe } from "../helpers/sanitize-html";
 
 type UserInfoType = {
   username: string | undefined;
@@ -177,7 +177,7 @@ export async function expandLink(
 
         botReply = await ctx.api.sendPhoto(chatId, new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=600`)), {
           ...replyOptions,
-          caption: template + `\n\n<b>${escapeHtml(truncatedTitle)}</b>\n${escapeHtml(truncatedDesc)}`,
+          caption: template + `\n\n<b>${escapeHtmlSafe(truncatedTitle)}</b>\n${escapeHtmlSafe(truncatedDesc)}`,
           parse_mode: "HTML",
         });
 
@@ -187,7 +187,7 @@ export async function expandLink(
           await ctx.api.sendAudio(chatId, new InputFile(new URL(audio)), {
             ...replyOptions,
             title: truncatedTitle,
-            caption: escapeHtml(audioDesc),
+            caption: escapeHtmlSafe(audioDesc),
             thumbnail: new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=200&h=200`)),
             parse_mode: "HTML",
             reply_markup: {
@@ -286,7 +286,7 @@ export async function expandLink(
 
           botReply = await ctx.api.sendPhoto(chatId, new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=600`)), {
             ...replyOptions,
-            caption: template + `\n\n<b>${escapeHtml(truncatedTitle)}</b>\n${escapeHtml(truncatedDesc)}`,
+            caption: template + `\n\n<b>${escapeHtmlSafe(truncatedTitle)}</b>\n${escapeHtmlSafe(truncatedDesc)}`,
             parse_mode: "HTML",
           });
 
@@ -296,7 +296,7 @@ export async function expandLink(
             await ctx.api.sendAudio(chatId, new InputFile(new URL(audio)), {
               ...replyOptions,
               title: truncatedTitle,
-              caption: escapeHtml(audioDesc),
+              caption: escapeHtmlSafe(audioDesc),
               thumbnail: new InputFile(new URL(`https://wsrv.nl/?url=${image}&w=200&h=200`)),
               parse_mode: "HTML",
               reply_markup: {

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -48,6 +48,7 @@ export function sanitizeHtmlForTelegram(html: string): string {
   const allowedTagsWithAttrs = /^(a)\s/i;
 
   // Strip all tags that are not in the allowed list
+  let openAnchorTags = 0;
   result = result.replace(/<([^>]*)>/g, (match, inner: string) => {
     const tagContent = inner.trim();
 
@@ -55,14 +56,20 @@ export function sanitizeHtmlForTelegram(html: string): string {
     if (tagContent.startsWith("/")) {
       const tagName = tagContent.slice(1).trim();
       if (allowedTags.test("/" + tagName)) return match;
-      if (/^a$/i.test(tagName)) return match;
+      if (/^a$/i.test(tagName) && openAnchorTags > 0) {
+        openAnchorTags--;
+        return match;
+      }
       return "";
     }
 
     // Self-closing or opening tag
     const tagName = tagContent.split(/[\s/>]/)[0];
     if (allowedTags.test(tagName)) return match;
-    if (allowedTagsWithAttrs.test(tagContent)) return match;
+    if (allowedTagsWithAttrs.test(tagContent)) {
+      openAnchorTags++;
+      return match;
+    }
     return "";
   });
 
@@ -148,6 +155,7 @@ export function truncateHtml(
   
   const plainText = html.replace(/<[^>]*>/g, "");
   const plainTextDecoded = decodeHtmlEntities(plainText);
-  
-  return { html: plainTextDecoded.slice(0, maxLength) + "…", isPlainText: true };
+  const needsTruncation = plainTextDecoded.length > maxLength;
+
+  return { html: plainTextDecoded.slice(0, maxLength) + (needsTruncation ? "…" : ""), isPlainText: true };
 }

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -58,3 +58,16 @@ export function sanitizeHtmlForTelegram(html: string): string {
 
   return result.trim();
 }
+
+/**
+ * Safely truncate HTML content without breaking tags.
+ * Strips all HTML tags, truncates to maxLength, then adds ellipsis if needed.
+ */
+export function truncateHtml(html: string, maxLength: number): string {
+  const plainText = html.replace(/<[^>]*>/g, "");
+  if (plainText.length <= maxLength) {
+    return html;
+  }
+  const stripped = plainText.slice(0, maxLength);
+  return stripped + "…";
+}

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -39,7 +39,7 @@ export function sanitizeHtmlForTelegram(html: string): string {
   result = result.replace(/<br\s*\/?>/gi, "\n");
 
   // Convert <img> tags — extract src as a link if present, otherwise strip
-  result = result.replace(/<img[^>]*\bsrc="([^"]*)"[^>]*>/gi, "[$1]");
+  result = result.replace(/<img[^>]*\bsrc=["']([^"']*)["'][^>]*>/gi, "[$1]");
 
   // Telegram supported tags (with attributes for <a> and <pre>):
   // <b>, <strong>, <i>, <em>, <u>, <ins>, <s>, <strike>, <del>,
@@ -114,16 +114,22 @@ function decodeHtmlEntities(text: string): string {
 
   const MAX_CODE_POINT = 0x10ffff;
 
-  return text
-    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => {
+  // Single-pass replacement to avoid cascading decodes (e.g. &#x26;lt; → & → <)
+  return text.replace(/&#x([0-9a-fA-F]+);|&#(\d+);|&([a-z]+);/gi, (match, hex, dec, named) => {
+    if (hex !== undefined) {
       const codePoint = parseInt(hex, 16);
       return codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : match;
-    })
-    .replace(/&#(\d+);/g, (match, dec) => {
+    }
+    if (dec !== undefined) {
       const codePoint = parseInt(dec, 10);
       return codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : match;
-    })
-    .replace(/&[a-z]+;/gi, (match) => entities[match.toLowerCase()] || match);
+    }
+    if (named !== undefined) {
+      const key = `&${named.toLowerCase()};`;
+      return entities[key] || match;
+    }
+    return match;
+  });
 }
 
 /**
@@ -140,7 +146,7 @@ export function truncateHtml(
     return { html, isPlainText: false };
   }
   
-  let plainText = html.replace(/<[^>]*>/g, "");
+  const plainText = html.replace(/<[^>]*>/g, "");
   const plainTextDecoded = decodeHtmlEntities(plainText);
   
   return { html: plainTextDecoded.slice(0, maxLength) + "…", isPlainText: true };

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -53,15 +53,6 @@ export function sanitizeHtmlForTelegram(html: string): string {
     return "";
   });
 
-  // Decode common HTML entities
-  result = result.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
-  result = result.replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
-  result = result.replace(/&amp;/g, "&");
-  result = result.replace(/&lt;/g, "<");
-  result = result.replace(/&gt;/g, ">");
-  result = result.replace(/&quot;/g, '"');
-  result = result.replace(/&apos;/g, "'");
-
   // Collapse excessive newlines (more than 2 consecutive)
   result = result.replace(/\n{3,}/g, "\n\n");
 

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -1,0 +1,57 @@
+/**
+ * Sanitize HTML content for Telegram's supported HTML subset.
+ * Converts block-level tags to newlines, keeps supported inline tags,
+ * and strips everything else.
+ */
+export function sanitizeHtmlForTelegram(html: string): string {
+  let result = html;
+
+  // Convert <p> tags to double newlines
+  result = result.replace(/<p[^>]*>/gi, "\n\n");
+  result = result.replace(/<\/p>/gi, "");
+
+  // Convert <br> tags to newlines
+  result = result.replace(/<br\s*\/?>/gi, "\n");
+
+  // Convert <img> tags — extract src as a link if present, otherwise strip
+  result = result.replace(/<img[^>]*\bsrc="([^"]*)"[^>]*>/gi, "[$1]");
+
+  // Telegram supported tags (with attributes for <a> and <pre>):
+  // <b>, <strong>, <i>, <em>, <u>, <ins>, <s>, <strike>, <del>,
+  // <a href="...">, <code>, <pre>, <blockquote>, <tg-spoiler>
+  const allowedTags = /^\/?(b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler)$/i;
+  const allowedTagsWithAttrs = /^(a)\s/i;
+
+  // Strip all tags that are not in the allowed list
+  result = result.replace(/<\/?([^>]*)>/g, (match, inner: string) => {
+    const tagContent = inner.trim();
+
+    // Closing tag: </tagname>
+    if (tagContent.startsWith("/")) {
+      const tagName = tagContent.slice(1).trim();
+      if (allowedTags.test("/" + tagName)) return match;
+      if (/^a$/i.test(tagName)) return match;
+      return "";
+    }
+
+    // Self-closing or opening tag
+    const tagName = tagContent.split(/[\s/>]/)[0];
+    if (allowedTags.test(tagName)) return match;
+    if (allowedTagsWithAttrs.test(tagContent)) return match;
+    return "";
+  });
+
+  // Decode common HTML entities
+  result = result.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
+  result = result.replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
+  result = result.replace(/&amp;/g, "&");
+  result = result.replace(/&lt;/g, "<");
+  result = result.replace(/&gt;/g, ">");
+  result = result.replace(/&quot;/g, '"');
+  result = result.replace(/&apos;/g, "'");
+
+  // Collapse excessive newlines (more than 2 consecutive)
+  result = result.replace(/\n{3,}/g, "\n\n");
+
+  return result.trim();
+}

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -35,7 +35,7 @@ export function sanitizeHtmlForTelegram(html: string): string {
   const allowedTagsWithAttrs = /^(a)\s/i;
 
   // Strip all tags that are not in the allowed list
-  result = result.replace(/<\/?([^>]*)>/g, (match, inner: string) => {
+  result = result.replace(/<([^>]*)>/g, (match, inner: string) => {
     const tagContent = inner.trim();
 
     // Closing tag: </tagname>

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -47,31 +47,45 @@ export function sanitizeHtmlForTelegram(html: string): string {
   const allowedTags = /^\/?(b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler)$/i;
   const allowedTagsWithAttrs = /^(a)\s/i;
 
-  // Strip all tags that are not in the allowed list
-  let openAnchorTags = 0;
+  // Strip all tags that are not in the allowed list and track balance
+  const openTags: string[] = [];
   result = result.replace(/<([^>]*)>/g, (match, inner: string) => {
     const tagContent = inner.trim();
 
     // Closing tag: </tagname>
     if (tagContent.startsWith("/")) {
-      const tagName = tagContent.slice(1).trim();
-      if (allowedTags.test("/" + tagName)) return match;
-      if (/^a$/i.test(tagName) && openAnchorTags > 0) {
-        openAnchorTags--;
-        return match;
+      const tagName = tagContent.slice(1).trim().toLowerCase();
+      if (allowedTags.test("/" + tagName) || tagName === "a") {
+        const lastOpenIndex = openTags.lastIndexOf(tagName);
+        if (lastOpenIndex !== -1) {
+          openTags.splice(lastOpenIndex, 1);
+          return match;
+        }
+        return "";
       }
       return "";
     }
 
     // Self-closing or opening tag
-    const tagName = tagContent.split(/[\s/>]/)[0];
-    if (allowedTags.test(tagName)) return match;
+    const tagName = tagContent.split(/[\s/>]/)[0].toLowerCase();
+    if (allowedTags.test(tagName)) {
+      if (!tagContent.includes("/")) {
+        openTags.push(tagName);
+      }
+      return match;
+    }
     if (allowedTagsWithAttrs.test(tagContent)) {
-      openAnchorTags++;
+      openTags.push(tagName);
       return match;
     }
     return "";
   });
+
+  // Close any remaining unclosed tags
+  while (openTags.length > 0) {
+    const tag = openTags.pop();
+    result += `</${tag}>`;
+  }
 
   // Collapse excessive newlines (more than 2 consecutive)
   result = result.replace(/\n{3,}/g, "\n\n");

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -2,12 +2,25 @@
  * Escape plain text for safe insertion into Telegram HTML messages.
  * Use this for external plain text (titles, usernames, descriptions)
  * that should render as literal text, not be parsed as HTML.
+ * 
+ * Note: This escapes plain text. If the input might already contain HTML entities,
+ * use escapeHtmlSafe() instead to avoid double-encoding.
  */
 export function escapeHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+/**
+ * Safely escape text that might already contain HTML entities.
+ * Decodes any existing entities first, then re-escapes to avoid double-encoding.
+ * Use this for external API data that might be pre-encoded.
+ */
+export function escapeHtmlSafe(text: string): string {
+  const decoded = decodeHtmlEntities(text);
+  return escapeHtml(decoded);
 }
 
 /**
@@ -60,20 +73,58 @@ export function sanitizeHtmlForTelegram(html: string): string {
 }
 
 /**
+ * Decode HTML entities to their character equivalents.
+ */
+function decodeHtmlEntities(text: string): string {
+  const entities: Record<string, string> = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": '"',
+    "&apos;": "'",
+    "&nbsp;": " ",
+    "&ndash;": "–",
+    "&mdash;": "—",
+    "&hellip;": "…",
+    "&rsquo;": "'",
+    "&lsquo;": "'",
+    "&rdquo;": '"',
+    "&ldquo;": '"',
+    "&bull;": "•",
+    "&middot;": "·",
+    "&trade;": "™",
+    "&copy;": "©",
+    "&reg;": "®",
+    "&deg;": "°",
+    "&plusmn;": "±",
+    "&times;": "×",
+    "&divide;": "÷",
+    "&ne;": "≠",
+    "&le;": "≤",
+    "&ge;": "≥",
+    "&infin;": "∞",
+    "&asymp;": "≈",
+    "&equiv;": "≡",
+    "&larr;": "←",
+    "&rarr;": "→",
+    "&uarr;": "↑",
+    "&darr;": "↓",
+    "&harr;": "↔",
+  };
+
+  return text
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&[a-z]+;/gi, (match) => entities[match.toLowerCase()] || match);
+}
+
+/**
  * Safely truncate HTML content without breaking tags or entities.
  * Strips all HTML tags and decodes entities, truncates to maxLength, then adds ellipsis if needed.
  */
 export function truncateHtml(html: string, maxLength: number): string {
   let plainText = html.replace(/<[^>]*>/g, "");
-  
-  plainText = plainText
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
+  plainText = decodeHtmlEntities(plainText);
   
   if (plainText.length <= maxLength) {
     return plainText;

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -129,19 +129,19 @@ function decodeHtmlEntities(text: string): string {
 /**
  * Safely truncate HTML content without breaking tags or entities.
  * Returns { html: string, isPlainText: boolean } where:
- * - If content fits, returns original HTML with tags (isPlainText: false)
- * - If truncation needed, strips tags and returns decoded plain text (isPlainText: true)
+ * - If HTML itself fits within maxLength, returns it with tags preserved (isPlainText: false)
+ * - Otherwise strips tags/decodes entities and returns truncated plain text (isPlainText: true)
  */
 export function truncateHtml(
   html: string,
   maxLength: number
 ): { html: string; isPlainText: boolean } {
-  let plainText = html.replace(/<[^>]*>/g, "");
-  const plainTextDecoded = decodeHtmlEntities(plainText);
-  
-  if (plainTextDecoded.length <= maxLength) {
+  if (html.length <= maxLength) {
     return { html, isPlainText: false };
   }
+  
+  let plainText = html.replace(/<[^>]*>/g, "");
+  const plainTextDecoded = decodeHtmlEntities(plainText);
   
   return { html: plainTextDecoded.slice(0, maxLength) + "…", isPlainText: true };
 }

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -68,14 +68,18 @@ export function sanitizeHtmlForTelegram(html: string): string {
 
     // Self-closing or opening tag
     const tagName = tagContent.split(/[\s/>]/)[0].toLowerCase();
+    const isSelfClosing = tagContent.endsWith("/");
+    
     if (allowedTags.test(tagName)) {
-      if (!tagContent.includes("/")) {
+      if (!isSelfClosing) {
         openTags.push(tagName);
       }
       return match;
     }
     if (allowedTagsWithAttrs.test(tagContent)) {
-      openTags.push(tagName);
+      if (!isSelfClosing) {
+        openTags.push(tagName);
+      }
       return match;
     }
     return "";

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -1,4 +1,16 @@
 /**
+ * Escape plain text for safe insertion into Telegram HTML messages.
+ * Use this for external plain text (titles, usernames, descriptions)
+ * that should render as literal text, not be parsed as HTML.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
  * Sanitize HTML content for Telegram's supported HTML subset.
  * Converts block-level tags to newlines, keeps supported inline tags,
  * and strips everything else.

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -112,22 +112,36 @@ function decodeHtmlEntities(text: string): string {
     "&harr;": "↔",
   };
 
+  const MAX_CODE_POINT = 0x10ffff;
+
   return text
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => {
+      const codePoint = parseInt(hex, 16);
+      return codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : match;
+    })
+    .replace(/&#(\d+);/g, (match, dec) => {
+      const codePoint = parseInt(dec, 10);
+      return codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : match;
+    })
     .replace(/&[a-z]+;/gi, (match) => entities[match.toLowerCase()] || match);
 }
 
 /**
  * Safely truncate HTML content without breaking tags or entities.
- * Strips all HTML tags and decodes entities, truncates to maxLength, then adds ellipsis if needed.
+ * Returns { html: string, isPlainText: boolean } where:
+ * - If content fits, returns original HTML with tags (isPlainText: false)
+ * - If truncation needed, strips tags and returns decoded plain text (isPlainText: true)
  */
-export function truncateHtml(html: string, maxLength: number): string {
+export function truncateHtml(
+  html: string,
+  maxLength: number
+): { html: string; isPlainText: boolean } {
   let plainText = html.replace(/<[^>]*>/g, "");
-  plainText = decodeHtmlEntities(plainText);
+  const plainTextDecoded = decodeHtmlEntities(plainText);
   
-  if (plainText.length <= maxLength) {
-    return plainText;
+  if (plainTextDecoded.length <= maxLength) {
+    return { html, isPlainText: false };
   }
-  return plainText.slice(0, maxLength) + "…";
+  
+  return { html: plainTextDecoded.slice(0, maxLength) + "…", isPlainText: true };
 }

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -60,14 +60,23 @@ export function sanitizeHtmlForTelegram(html: string): string {
 }
 
 /**
- * Safely truncate HTML content without breaking tags.
- * Strips all HTML tags, truncates to maxLength, then adds ellipsis if needed.
+ * Safely truncate HTML content without breaking tags or entities.
+ * Strips all HTML tags and decodes entities, truncates to maxLength, then adds ellipsis if needed.
  */
 export function truncateHtml(html: string, maxLength: number): string {
-  const plainText = html.replace(/<[^>]*>/g, "");
+  let plainText = html.replace(/<[^>]*>/g, "");
+  
+  plainText = plainText
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+  
   if (plainText.length <= maxLength) {
-    return html;
+    return plainText;
   }
-  const stripped = plainText.slice(0, maxLength);
-  return stripped + "…";
+  return plainText.slice(0, maxLength) + "…";
 }

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -68,20 +68,15 @@ export function sanitizeHtmlForTelegram(html: string): string {
       return "";
     }
 
-    // Self-closing or opening tag
+    // Opening tag (allowed tags are never self-closing void elements)
     const tagName = tagContent.split(/[\s/>]/)[0].toLowerCase();
-    const isSelfClosing = tagContent.endsWith("/");
     
     if (allowedTags.test(tagName)) {
-      if (!isSelfClosing) {
-        openTags.push(tagName);
-      }
+      openTags.push(tagName);
       return match;
     }
     if (allowedTagsWithAttrs.test(tagContent)) {
-      if (!isSelfClosing) {
-        openTags.push(tagName);
-      }
+      openTags.push(tagName);
       return match;
     }
     return "";

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -32,7 +32,7 @@ export function sanitizeHtmlForTelegram(html: string): string {
   let result = html;
 
   // Convert <p> tags to double newlines
-  result = result.replace(/<p[^>]*>/gi, "\n\n");
+  result = result.replace(/<p\b[^>]*>/gi, "\n\n");
   result = result.replace(/<\/p>/gi, "");
 
   // Convert <br> tags to newlines

--- a/helpers/sanitize-html.ts
+++ b/helpers/sanitize-html.ts
@@ -6,7 +6,8 @@
  * Note: This escapes plain text. If the input might already contain HTML entities,
  * use escapeHtmlSafe() instead to avoid double-encoding.
  */
-export function escapeHtml(text: string): string {
+export function escapeHtml(text: string | null | undefined): string {
+  if (!text) return "";
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -18,7 +19,8 @@ export function escapeHtml(text: string): string {
  * Decodes any existing entities first, then re-escapes to avoid double-encoding.
  * Use this for external API data that might be pre-encoded.
  */
-export function escapeHtmlSafe(text: string): string {
+export function escapeHtmlSafe(text: string | null | undefined): string {
+  if (!text) return "";
   const decoded = decodeHtmlEntities(text);
   return escapeHtml(decoded);
 }

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -25,7 +25,7 @@ import {
 import { getHackerNewsMetadata } from "./hacker-news-metadata";
 import { notifyAdmin } from "./notifier";
 import { logger } from "./logger";
-import { sanitizeHtmlForTelegram, escapeHtml } from "./sanitize-html";
+import { sanitizeHtmlForTelegram, escapeHtml, truncateHtml } from "./sanitize-html";
 
 export const hasPermissionToDeleteMessageTemplate = `✅ I have permissions to automatically delete original messages when expanding links.`;
 export const missingPermissionToDeleteMessageTemplate = `🔐 An admin of this chat needs to give me permissions to automatically delete messages when expanding links.`;
@@ -198,7 +198,7 @@ export const expandedMessageTemplate = async (
       const metadata = await getHackerNewsMetadata(hnPostId);
       const { title, user, time_ago, comments_count, url, content } = metadata.post;
       const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
-      const truncated = sanitized.length > 3072 ? sanitized.slice(0, 3072) + "…" : sanitized;
+      const truncated = truncateHtml(sanitized, 3072);
       const body = truncated !== "" ? `\n${truncated}\n` : "";
 
       includedLink = `<b>${title ? escapeHtml(title) : "Comment"}</b>

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -25,7 +25,7 @@ import {
 import { getHackerNewsMetadata } from "./hacker-news-metadata";
 import { notifyAdmin } from "./notifier";
 import { logger } from "./logger";
-import { sanitizeHtmlForTelegram } from "./sanitize-html";
+import { sanitizeHtmlForTelegram, escapeHtml } from "./sanitize-html";
 
 export const hasPermissionToDeleteMessageTemplate = `✅ I have permissions to automatically delete original messages when expanding links.`;
 export const missingPermissionToDeleteMessageTemplate = `🔐 An admin of this chat needs to give me permissions to automatically delete messages when expanding links.`;
@@ -201,8 +201,8 @@ export const expandedMessageTemplate = async (
       const truncated = sanitized.length > 3072 ? sanitized.slice(0, 3072) + "…" : sanitized;
       const body = truncated !== "" ? `\n${truncated}\n` : "";
 
-      includedLink = `<b>${title ? title : "Comment"}</b>
-${comments_count} replies | ${time_ago} by ${user}
+      includedLink = `<b>${title ? escapeHtml(title) : "Comment"}</b>
+${comments_count} replies | ${time_ago} by ${escapeHtml(user)}
 ${link}
 ${body}
 ${url ? url : ""}`;

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -202,7 +202,7 @@ export const expandedMessageTemplate = async (
       const body = truncated !== "" ? `\n${truncated}\n` : "";
 
       includedLink = `<b>${title ? escapeHtml(title) : "Comment"}</b>
-${comments_count} replies | ${time_ago} by ${escapeHtml(user)}
+${comments_count} replies | ${time_ago} by ${user ? escapeHtml(user) : "unknown"}
 ${link}
 ${body}
 ${url ? url : ""}`;

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -198,8 +198,8 @@ export const expandedMessageTemplate = async (
       const metadata = await getHackerNewsMetadata(hnPostId);
       const { title, user, time_ago, comments_count, url, content } = metadata.post;
       const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
-      const truncated = truncateHtml(sanitized, 3072);
-      const body = truncated !== "" ? `\n${escapeHtml(truncated)}\n` : "";
+      const { html: truncated, isPlainText } = truncateHtml(sanitized, 3072);
+      const body = truncated !== "" ? `\n${isPlainText ? escapeHtml(truncated) : truncated}\n` : "";
 
       includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
 ${comments_count} replies | ${time_ago} by ${user ? escapeHtmlSafe(user) : "unknown"}

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -202,10 +202,10 @@ export const expandedMessageTemplate = async (
       const body = truncated !== "" ? `\n${isPlainText ? escapeHtml(truncated) : truncated}\n` : "";
 
       includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
-${comments_count} replies | ${escapeHtml(time_ago)} by ${user ? escapeHtmlSafe(user) : "unknown"}
+${comments_count} replies | ${escapeHtmlSafe(time_ago)} by ${user ? escapeHtmlSafe(user) : "unknown"}
 ${escapeHtml(link)}
 ${body}
-${url ? escapeHtml(url) : ""}`;
+${url ? escapeHtmlSafe(url) : ""}`;
     } catch (error) {
       logger.error("Error fetching HN metadata for template: {error}", { error });
       notifyAdmin(error);

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -25,7 +25,7 @@ import {
 import { getHackerNewsMetadata } from "./hacker-news-metadata";
 import { notifyAdmin } from "./notifier";
 import { logger } from "./logger";
-import { sanitizeHtmlForTelegram, escapeHtml, truncateHtml } from "./sanitize-html";
+import { sanitizeHtmlForTelegram, escapeHtml, escapeHtmlSafe, truncateHtml } from "./sanitize-html";
 
 export const hasPermissionToDeleteMessageTemplate = `✅ I have permissions to automatically delete original messages when expanding links.`;
 export const missingPermissionToDeleteMessageTemplate = `🔐 An admin of this chat needs to give me permissions to automatically delete messages when expanding links.`;
@@ -201,8 +201,8 @@ export const expandedMessageTemplate = async (
       const truncated = truncateHtml(sanitized, 3072);
       const body = truncated !== "" ? `\n${escapeHtml(truncated)}\n` : "";
 
-      includedLink = `<b>${title ? escapeHtml(title) : "Comment"}</b>
-${comments_count} replies | ${time_ago} by ${user ? escapeHtml(user) : "unknown"}
+      includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
+${comments_count} replies | ${time_ago} by ${user ? escapeHtmlSafe(user) : "unknown"}
 ${link}
 ${body}
 ${url ? url : ""}`;

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -196,6 +196,7 @@ export const expandedMessageTemplate = async (
     try {
       const hnPostId = link?.split("id=")[1];
       const metadata = await getHackerNewsMetadata(hnPostId);
+      if (!metadata?.post) return expandedMessageTemplate;
       const { title, user, time_ago, comments_count, url, content } = metadata.post;
       const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
       const { html: truncated, isPlainText } = truncateHtml(sanitized, 3072);

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -182,7 +182,7 @@ export const expandedMessageTemplate = async (
   lastName?: string,
   text?: string,
   link?: string
-) => {
+): Promise<string> => {
   // TODO: this function is a clusterfuck of ugly template literals. refactor in the future.
   const bothNames = firstName && lastName;
   const nameTemplate = bothNames ? `${firstName} ${lastName}` : firstName ?? lastName;
@@ -196,18 +196,19 @@ export const expandedMessageTemplate = async (
     try {
       const hnPostId = link?.split("id=")[1];
       const metadata = await getHackerNewsMetadata(hnPostId);
-      if (!metadata?.post) return expandedMessageTemplate;
-      const { title, user, time_ago, comments_count, url, content } = metadata.post;
-      const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
-      const { html: truncated, isPlainText } = truncateHtml(sanitized, 3072);
-      const body = truncated !== "" ? `\n${isPlainText ? escapeHtml(truncated) : truncated}\n` : "";
+      if (metadata?.post) {
+        const { title, user, time_ago, comments_count, url, content } = metadata.post;
+        const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
+        const { html: truncated, isPlainText } = truncateHtml(sanitized, 3072);
+        const body = truncated !== "" ? `\n${isPlainText ? escapeHtml(truncated) : truncated}\n` : "";
 
-      const timeAgoText = time_ago ? `${escapeHtmlSafe(time_ago)} ` : "";
-      includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
+        const timeAgoText = time_ago ? `${escapeHtmlSafe(time_ago)} ` : "";
+        includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
 ${comments_count ?? 0} replies | ${timeAgoText}by ${user ? escapeHtmlSafe(user) : "unknown"}
 ${escapeHtml(link)}
 ${body}
 ${url ? escapeHtmlSafe(url) : ""}`;
+      }
     } catch (error) {
       logger.error("Error fetching HN metadata for template: {error}", { error });
       notifyAdmin(error);

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -25,6 +25,7 @@ import {
 import { getHackerNewsMetadata } from "./hacker-news-metadata";
 import { notifyAdmin } from "./notifier";
 import { logger } from "./logger";
+import { sanitizeHtmlForTelegram } from "./sanitize-html";
 
 export const hasPermissionToDeleteMessageTemplate = `✅ I have permissions to automatically delete original messages when expanding links.`;
 export const missingPermissionToDeleteMessageTemplate = `🔐 An admin of this chat needs to give me permissions to automatically delete messages when expanding links.`;
@@ -196,7 +197,9 @@ export const expandedMessageTemplate = async (
       const hnPostId = link?.split("id=")[1];
       const metadata = await getHackerNewsMetadata(hnPostId);
       const { title, user, time_ago, comments_count, url, content } = metadata.post;
-      const body = content && content.trim() !== "" ? `\n${content}\n` : "";
+      const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
+      const truncated = sanitized.length > 3072 ? sanitized.slice(0, 3072) + "…" : sanitized;
+      const body = truncated !== "" ? `\n${truncated}\n` : "";
 
       includedLink = `<b>${title ? title : "Comment"}</b>
 ${comments_count} replies | ${time_ago} by ${user}

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -199,7 +199,7 @@ export const expandedMessageTemplate = async (
       const { title, user, time_ago, comments_count, url, content } = metadata.post;
       const sanitized = content ? sanitizeHtmlForTelegram(content) : "";
       const truncated = truncateHtml(sanitized, 3072);
-      const body = truncated !== "" ? `\n${truncated}\n` : "";
+      const body = truncated !== "" ? `\n${escapeHtml(truncated)}\n` : "";
 
       includedLink = `<b>${title ? escapeHtml(title) : "Comment"}</b>
 ${comments_count} replies | ${time_ago} by ${user ? escapeHtml(user) : "unknown"}

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -201,8 +201,9 @@ export const expandedMessageTemplate = async (
       const { html: truncated, isPlainText } = truncateHtml(sanitized, 3072);
       const body = truncated !== "" ? `\n${isPlainText ? escapeHtml(truncated) : truncated}\n` : "";
 
+      const timeAgoText = time_ago ? `${escapeHtmlSafe(time_ago)} ` : "";
       includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
-${comments_count} replies | ${escapeHtmlSafe(time_ago)} by ${user ? escapeHtmlSafe(user) : "unknown"}
+${comments_count ?? 0} replies | ${timeAgoText}by ${user ? escapeHtmlSafe(user) : "unknown"}
 ${escapeHtml(link)}
 ${body}
 ${url ? escapeHtmlSafe(url) : ""}`;

--- a/helpers/templates.ts
+++ b/helpers/templates.ts
@@ -202,10 +202,10 @@ export const expandedMessageTemplate = async (
       const body = truncated !== "" ? `\n${isPlainText ? escapeHtml(truncated) : truncated}\n` : "";
 
       includedLink = `<b>${title ? escapeHtmlSafe(title) : "Comment"}</b>
-${comments_count} replies | ${time_ago} by ${user ? escapeHtmlSafe(user) : "unknown"}
-${link}
+${comments_count} replies | ${escapeHtml(time_ago)} by ${user ? escapeHtmlSafe(user) : "unknown"}
+${escapeHtml(link)}
 ${body}
-${url ? url : ""}`;
+${url ? escapeHtml(url) : ""}`;
     } catch (error) {
       logger.error("Error fetching HN metadata for template: {error}", { error });
       notifyAdmin(error);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk formatting/sanitization changes, but they may slightly alter how Hacker News and Spotify previews render in Telegram.
> 
> **Overview**
> Improves Telegram message safety/robustness by introducing `helpers/sanitize-html.ts` utilities to escape text, sanitize allowed Telegram HTML, and truncate long HTML content.
> 
> Updates Hacker News expansion rendering in `expandedMessageTemplate` to tolerate missing metadata, sanitize/escape external fields (title/user/time/link/url), and safely truncate/sanitize comment content before embedding.
> 
> Hardens Spotify expansions in `expand-link.ts` by guarding against missing `title`/`description` and escaping those fields in photo/audio captions to avoid broken HTML parsing or injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b826a06605d7746d69b5a44e8c8c5d215ae3fc95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->