### PR TITLE
Update Instagram embed services order (prioritize vxinstagram)

### DIFF
--- a/helpers/platforms.ts
+++ b/helpers/platforms.ts
@@ -1,8 +1,8 @@
 export const INSTAGRAM_DOMAINS = [
-  "zzinstagram.com",
-  "eeinstagram.com",
-  "kkinstagram.com",
   "vxinstagram.com",
+  "eeinstagram.com",
+  "zzinstagram.com",
+  "kkinstagram.com",
   "fxstagram.com",
   "uuinstagram.com",
 ];


### PR DESCRIPTION
This PR updates the priority order of the Instagram embed services, setting `vxinstagram` as the primary resolver and `eeinstagram` as the first fallback. 

**Why the change?**
A recently merged PR in the vxinstagram repo (https://github.com/Lainmode/InstagramEmbed-vxinstagram/pull/6) has significantly improved its reliability. It is currently the most consistent service for resolving Instagram embeds by far. 

Based on recent usage and testing, `eeinstagram` seems to be the second most reliable option right now, so it has been placed right after it in the fallback chain. 

This should result in far fewer failed previews for users dropping IG links in the chat.