### PR TITLE
chore: Update Instagram embed service links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Some Twitter links stopped expanding inside Telegram which made it extremely ann
 ## Supported platforms
 
 - _Twitter / X_ using [fxtwitter.com](https://fxtwitter.com) and [vxtwitter.com](https://vxtwitter.com)
-- _Instagram_ using [eeinstagram.com](https://eeinstagram.com), [fxstagram.com](https://fxstagram.com), [uuinstagram.com](https://uuinstagram.com), [vxinstagram.com](https://vxinstagram.com) and [kkinstagram.com](https://kkinstagram.com)
+- _Instagram_ using [eeinstagram.com](https://eeinstagram.com), [xnstagram.com](https://xnstagram.com), [vxinstagram.com](https://vxinstagram.com), [zzinstagram.com](https://zzinstagram.com) and [kkclip.com](https://kkclip.com)
 - _TikTok_ using [tfxktok.com](https://tfxktok.com), [kktiktok.com](https://kktiktok.com), [tiktokez.com](https://tiktokez.com) and [tnktok.com](https://tnktok.com)
 - _Bluesky_ using [fxbsky.app](https://fxbsky.app)
 - _Reddit_ using [rxddit.com](https://rxddit.com)

--- a/helpers/platforms.ts
+++ b/helpers/platforms.ts
@@ -2,9 +2,8 @@ export const INSTAGRAM_DOMAINS = [
   "vxinstagram.com",
   "eeinstagram.com",
   "zzinstagram.com",
-  "kkinstagram.com",
-  "fxstagram.com",
-  "uuinstagram.com",
+  "kkclip.com",
+  "xnstagram.com",
 ];
 export const TIKTOK_DOMAINS = ["tnktok.com", "tfxktok.com", "kktiktok.com", "tiktxk.com", "tiktokez.com"];
 export const TWITTER_DOMAINS = ["fxtwitter.com", "vxtwitter.com", "fixupx.com", "fixvx.com", "twitterez.com"];


### PR DESCRIPTION
README.md: Add zzinstagram 

uuinstagram:
https://github.com/Wikidepia/InstaFix is an archived project and no longer feasible.

kkinstagram -> kkclip:
Embed service link is changed. 

fxstagram -> xnstagram:
Embed service link is changed. 
As of writing, xnstagram is showing "Out of request" error through embed, but I kept here in hopes that service gets around; otherwise, it should be removed.