### PR TITLE
Make zzinstagram the default Instagram embed service

### DIFF
--- a/helpers/platforms.ts
+++ b/helpers/platforms.ts
@@ -1,7 +1,7 @@
 export const INSTAGRAM_DOMAINS = [
+  "zzinstagram.com",
   "vxinstagram.com",
   "eeinstagram.com",
-  "zzinstagram.com",
   "kkclip.com",
   "xnstagram.com",
 ];

--- a/link-listener-channel.ts
+++ b/link-listener-channel.ts
@@ -12,7 +12,7 @@ import { logger } from "./helpers/logger";
 const DOMAIN_REPLACEMENTS: { platform: TogglePlatformKey; from: string; to: string }[] = [
   { platform: "twitter", from: "twitter.com/", to: "fxtwitter.com/" },
   { platform: "twitter", from: "x.com/", to: "fxtwitter.com/" },
-  { platform: "instagram", from: "instagram.com/", to: "eeinstagram.com/" },
+  { platform: "instagram", from: "instagram.com/", to: "zzinstagram.com/" },
   { platform: "tiktok", from: "vt.tiktok.com/", to: "vm.tfxktok.com/" },
   { platform: "tiktok", from: "lite.tiktok.com/", to: "tiktokez.com/" },
   { platform: "tiktok", from: "tiktok.com/", to: "tfxktok.com/" },


### PR DESCRIPTION
## Summary
- Reorder `INSTAGRAM_DOMAINS` so **zzinstagram.com** is the default embed service, with **vxinstagram.com** second (eeinstagram, kkclip, xnstagram unchanged after that)
- Sync the hardcoded channel-post replacement in `link-listener-channel.ts` from `eeinstagram.com` to `zzinstagram.com` — it has historically tracked the default service but was never updated when vxinstagram became the default in #92

Since expansion always uses `INSTAGRAM_DOMAINS[0]`, this makes zzinstagram the default for regular links, share links, and channels, and the switch-service button cycles in the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes default mirror ordering and channel URL rewriting for Instagram; no auth, data, or core business logic changes.
> 
> **Overview**
> **zzinstagram.com** is now the default Instagram mirror for link expansion and the first option when users cycle embed services.
> 
> `INSTAGRAM_DOMAINS` is reordered so `zzinstagram.com` is index `0` (with `vxinstagram.com` second); regular links, share-link resolution, and related expansion paths that use `INSTAGRAM_DOMAINS[0]` will rewrite to zzinstagram instead of the previous default.
> 
> Channel posts are aligned with that default: `link-listener-channel.ts` rewrites `instagram.com/` to `zzinstagram.com/` instead of `eeinstagram.com/`, matching the pattern used for other platforms’ primary mirror.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0408a85b62565e72efaeef788cf626b29d9c184b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->