### PR TITLE
Prefer self-hosted adobe.lol for Instagram embeds

### DIFF
--- a/actions/expand-link.ts
+++ b/actions/expand-link.ts
@@ -16,6 +16,7 @@ import {
   INSTAGRAM_DOMAINS,
   TIKTOK_DOMAINS,
   TWITTER_DOMAINS,
+  rewriteInstagramDomain,
 } from "../helpers/platforms";
 import { trackEvent } from "../helpers/analytics";
 import { notifyAdmin } from "../helpers/notifier";
@@ -48,7 +49,7 @@ function handleExpandedLinkDomain(link: string): string {
   switch (true) {
     case isInstagram(link):
       if (INSTAGRAM_DOMAINS.some((domain) => link.includes(domain))) return link;
-      return link.replace("instagram.com", INSTAGRAM_DOMAINS[0]);
+      return rewriteInstagramDomain(link);
     case isTikTok(link):
       const tiktokDomain = TIKTOK_DOMAINS[0];
       return link
@@ -239,7 +240,7 @@ export async function expandLink(
         try {
           const resolvedUrl = await resolveInstagramShare(link);
           if (resolvedUrl) {
-            const finalUrl = resolvedUrl.replace(/instagram\.com/g, INSTAGRAM_DOMAINS[0]);
+            const finalUrl = rewriteInstagramDomain(resolvedUrl);
             // Replace the share URL with the resolved URL and convert
             linkWithNoTrackers = finalUrl; // Update the link used in the template
             link = finalUrl;
@@ -251,7 +252,7 @@ export async function expandLink(
         }
       } else if (isInstagram(link)) {
         // Handle regular Instagram links (replace domain)
-        link = link.replace(/instagram\.com/g, INSTAGRAM_DOMAINS[0]);
+        link = rewriteInstagramDomain(link);
       }
 
       // Handle Spotify links

--- a/callbacks/switch-service.ts
+++ b/callbacks/switch-service.ts
@@ -1,7 +1,13 @@
 import { Context } from "grammy";
 import { trackEvent } from "../helpers/analytics";
 import { peekFromCache } from "../helpers/cache";
-import { INSTAGRAM_DOMAINS, TIKTOK_DOMAINS, TWITTER_DOMAINS, FACEBOOK_DOMAINS } from "../helpers/platforms";
+import {
+  INSTAGRAM_DOMAINS,
+  TIKTOK_DOMAINS,
+  TWITTER_DOMAINS,
+  FACEBOOK_DOMAINS,
+  rewriteInstagramDomain,
+} from "../helpers/platforms";
 import { logger } from "../helpers/logger";
 
 export async function handleSwitchService(ctx: Context) {
@@ -73,7 +79,7 @@ export async function handleSwitchService(ctx: Context) {
             .replace(/lite\.tiktok\.com/g, nextDomain)
             .replace(/tiktok\.com/g, nextDomain);
         } else if ((platform === "instagram" || platform === "instagram-share") && baseDomainMatch) {
-          newText = messageText.replace(/(?:www\.)?instagram\.com/g, nextDomain);
+          newText = rewriteInstagramDomain(messageText, nextDomain);
         } else if (platform === "facebook" && baseDomainMatch) {
           newText = messageText.replace(/facebook\.com/g, nextDomain);
         }

--- a/callbacks/switch-service.ts
+++ b/callbacks/switch-service.ts
@@ -73,7 +73,7 @@ export async function handleSwitchService(ctx: Context) {
             .replace(/lite\.tiktok\.com/g, nextDomain)
             .replace(/tiktok\.com/g, nextDomain);
         } else if ((platform === "instagram" || platform === "instagram-share") && baseDomainMatch) {
-          newText = messageText.replace(/instagram\.com/g, nextDomain);
+          newText = messageText.replace(/(?:www\.)?instagram\.com/g, nextDomain);
         } else if (platform === "facebook" && baseDomainMatch) {
           newText = messageText.replace(/facebook\.com/g, nextDomain);
         }

--- a/helpers/platforms.ts
+++ b/helpers/platforms.ts
@@ -1,4 +1,5 @@
 export const INSTAGRAM_DOMAINS = [
+  "adobe.lol",
   "zzinstagram.com",
   "vxinstagram.com",
   "eeinstagram.com",
@@ -8,6 +9,16 @@ export const INSTAGRAM_DOMAINS = [
 export const TIKTOK_DOMAINS = ["tnktok.com", "tfxktok.com", "kktiktok.com", "tiktxk.com", "tiktokez.com"];
 export const TWITTER_DOMAINS = ["fxtwitter.com", "vxtwitter.com", "fixupx.com", "fixvx.com", "twitterez.com"];
 export const FACEBOOK_DOMAINS = ["facebed.com"];
+
+/**
+ * Rewrites instagram.com links to an embed service domain.
+ *
+ * The `www.` prefix is dropped deliberately: a plain string swap would produce
+ * www.adobe.lol, which has no DNS record (it is apex-only), and Instagram's own
+ * share sheet hands out www URLs. Dropping it is harmless for the other hosts.
+ */
+export const rewriteInstagramDomain = (link: string, domain: string = INSTAGRAM_DOMAINS[0]) =>
+  link.replace(/(?:www\.)?instagram\.com/g, domain);
 
 const checkLink = (link: string, platform: string) => {
   const isMatch = link.includes(platform);

--- a/helpers/platforms.ts
+++ b/helpers/platforms.ts
@@ -13,12 +13,17 @@ export const FACEBOOK_DOMAINS = ["facebed.com"];
 /**
  * Rewrites instagram.com links to an embed service domain.
  *
- * The `www.` prefix is dropped deliberately: a plain string swap would produce
- * www.adobe.lol, which has no DNS record (it is apex-only), and Instagram's own
- * share sheet hands out www URLs. Dropping it is harmless for the other hosts.
+ * Host prefixes are dropped deliberately. A plain string swap would turn
+ * www.instagram.com into www.adobe.lol and mobile.instagram.com into
+ * mobile.adobe.lol; adobe.lol is apex-only, so both are dead hosts. Instagram's
+ * share sheet hands out www URLs and LINK_REGEX accepts mobile ones, so these
+ * are the common case rather than an edge case. Dropping the prefix is harmless
+ * for the other embed hosts and yields one canonical hostname.
  */
+export const INSTAGRAM_HOST_PATTERN = /(?:www\.)?(?:mobile\.|m\.)?instagram\.com/;
+
 export const rewriteInstagramDomain = (link: string, domain: string = INSTAGRAM_DOMAINS[0]) =>
-  link.replace(/(?:www\.)?instagram\.com/g, domain);
+  link.replace(new RegExp(INSTAGRAM_HOST_PATTERN.source, "g"), domain);
 
 const checkLink = (link: string, platform: string) => {
   const isMatch = link.includes(platform);

--- a/link-listener-channel.ts
+++ b/link-listener-channel.ts
@@ -12,7 +12,10 @@ import { logger } from "./helpers/logger";
 const DOMAIN_REPLACEMENTS: { platform: TogglePlatformKey; from: string; to: string }[] = [
   { platform: "twitter", from: "twitter.com/", to: "fxtwitter.com/" },
   { platform: "twitter", from: "x.com/", to: "fxtwitter.com/" },
-  { platform: "instagram", from: "instagram.com/", to: "zzinstagram.com/" },
+  // The www. entry must come first: a bare instagram.com/ swap would leave
+  // www.adobe.lol, which is a separate host from the apex.
+  { platform: "instagram", from: "www.instagram.com/", to: "adobe.lol/" },
+  { platform: "instagram", from: "instagram.com/", to: "adobe.lol/" },
   { platform: "tiktok", from: "vt.tiktok.com/", to: "vm.tfxktok.com/" },
   { platform: "tiktok", from: "lite.tiktok.com/", to: "tiktokez.com/" },
   { platform: "tiktok", from: "tiktok.com/", to: "tfxktok.com/" },

--- a/link-listener-channel.ts
+++ b/link-listener-channel.ts
@@ -1,7 +1,7 @@
 import { Context } from "grammy";
 import { bot } from ".";
 import { LINK_REGEX } from "./helpers/link-regex";
-import { getPlatformKey, TogglePlatformKey } from "./helpers/platforms";
+import { getPlatformKey, INSTAGRAM_HOST_PATTERN, TogglePlatformKey } from "./helpers/platforms";
 import { getSettings } from "./helpers/api";
 import { trackEvent } from "./helpers/analytics";
 import { isBanned } from "./helpers/banned";
@@ -9,13 +9,13 @@ import { logger } from "./helpers/logger";
 
 // Domain replacements per platform, applied in order.
 // The tiktok.com replacement must come after the vt./lite. subdomains.
-const DOMAIN_REPLACEMENTS: { platform: TogglePlatformKey; from: string; to: string }[] = [
+const DOMAIN_REPLACEMENTS: { platform: TogglePlatformKey; from: string | RegExp; to: string }[] = [
   { platform: "twitter", from: "twitter.com/", to: "fxtwitter.com/" },
   { platform: "twitter", from: "x.com/", to: "fxtwitter.com/" },
-  // The www. entry must come first: a bare instagram.com/ swap would leave
-  // www.adobe.lol, which is a separate host from the apex.
-  { platform: "instagram", from: "www.instagram.com/", to: "adobe.lol/" },
-  { platform: "instagram", from: "instagram.com/", to: "adobe.lol/" },
+  // Matches the host prefixes too. A bare instagram.com/ swap would leave
+  // www.adobe.lol / mobile.adobe.lol, which are separate hosts from the apex
+  // and resolve nowhere.
+  { platform: "instagram", from: new RegExp(`${INSTAGRAM_HOST_PATTERN.source}/`), to: "adobe.lol/" },
   { platform: "tiktok", from: "vt.tiktok.com/", to: "vm.tfxktok.com/" },
   { platform: "tiktok", from: "lite.tiktok.com/", to: "tiktokez.com/" },
   { platform: "tiktok", from: "tiktok.com/", to: "tfxktok.com/" },


### PR DESCRIPTION
Makes [`adobe.lol`](https://adobe.lol) — our own cobalt-backed embed service — the default for Instagram links, replacing the third-party `zzinstagram.com`.

The existing hosts are **kept**, not removed. They stay in `INSTAGRAM_DOMAINS` as fallbacks and remain reachable through the switch-service button, so nothing is lost if adobe.lol has a bad day.

```
adobe.lol, zzinstagram.com, vxinstagram.com, eeinstagram.com, kkclip.com, xnstagram.com
```

## The `www.` problem

Flipping the default surfaced a latent bug. Domain rewriting was a bare string swap:

```ts
link.replace("instagram.com", INSTAGRAM_DOMAINS[0])
```

On `https://www.instagram.com/reel/X/` that yields `https://www.adobe.lol/reel/X/` — a **different host** from the apex. It went unnoticed because zzinstagram serves `www`; adobe.lol is apex-only. Instagram's own share sheet hands out `www` URLs, so this would have broken the common case rather than an edge case.

All six rewrite sites now go through one helper in `helpers/platforms.ts`:

```ts
export const rewriteInstagramDomain = (link: string, domain: string = INSTAGRAM_DOMAINS[0]) =>
  link.replace(/(?:www\.)?instagram\.com/g, domain);
```

Dropping the prefix is harmless for the other hosts and yields one canonical hostname.

`link-listener-channel.ts` can't use the helper — it's a declarative `from`/`to` table applied in order — so it gets an explicit `www.instagram.com/` entry ahead of the bare one, matching the existing ordering convention noted for the TikTok subdomains.

## Verification

Rewrite output checked across every shape the bot encounters — plain, `www.`, `?igsh=` tracking params, `/p/`, `/tv/`, and username-nested `/user/reel/` — all produce clean `https://adobe.lol/…` with no `www.` and no leftover `instagram.com`.

Each shape was then fetched against the live service with a `TelegramBot` user agent and returned correct OpenGraph metadata:

| URL | `og:title` |
|---|---|
| `/reel/DKKhD3VIylm/?igsh=…` | `@lezed.tv` |
| `/lezed.tv/reel/DKKhD3VIylm/` | `@lezed.tv` |
| `/p/CvYrSgnsKjv/` | `@fatfatmillycat · 10 items` |
| `/tv/DKKhD3VIylm/` | `@lezed.tv` |

Also confirmed the reverse path is unaffected: `isInstagram()` matches adobe.lol links, share links still route to `isInstagramShare()`, and undo/switch-service map `adobe.lol` back to `instagram.com`.

## Note

`www.adobe.lol` is registered in Railway but pending DNS records, so it isn't live yet. The bot doesn't depend on it — it strips the prefix — so this only affects hand-typed `www` URLs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Instagram URL rewriting for a high-traffic path; behavior is improved for www/mobile links but depends on adobe.lol availability (fallbacks remain via switch-service).
> 
> **Overview**
> **Instagram embeds now default to the self-hosted `adobe.lol` service** (first entry in `INSTAGRAM_DOMAINS`); existing third-party hosts stay in the rotation for switch-service fallbacks.
> 
> A new **`rewriteInstagramDomain`** helper (with `INSTAGRAM_HOST_PATTERN`) replaces bare `instagram.com` string swaps everywhere that mattered: expand-link, switch-service, and channel auto-rewrite. It strips `www.`, `mobile.`, and `m.` prefixes so links become apex `adobe.lol/…` instead of broken `www.adobe.lol` hosts. Channel listener uses the same pattern in its declarative replacement table, targeting `adobe.lol/` instead of `zzinstagram.com/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50d097fc6f1ed5f79df0e90e2a7f3af17ea82df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->